### PR TITLE
Position and "featured" features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@
 
 Smartcontracts to provide the DAppNode Package Directory
 
-Last deployment at [0xc8330fb0b7d80a7be4edb624139e15ec1f3ffea3](https://etherscan.io/address/0xc8330fb0b7d80a7be4edb624139e15ec1f3ffea3)
+Last deployment at [0xf19f629642c6697af77d8316bef8de0de3a27a70](https://etherscan.io/address/0xf19f629642c6697af77d8316bef8de0de3a27a70)
 

--- a/contracts/DAppNodePackageDirectory.sol
+++ b/contracts/DAppNodePackageDirectory.sol
@@ -85,7 +85,7 @@ contract DAppNodePackageDirectory is Owned,Escapable {
         }
         c.status = status;
         // An event to notify that a new package has been added
-        PackageAdded(idPackage,name);
+        PackageAdded(idPackage, name);
     }
 
     /// @notice Update a DAppNode package
@@ -105,7 +105,7 @@ contract DAppNodePackageDirectory is Owned,Escapable {
         c.position = position;
         c.status = status;
         // An event to notify that a package has been updated
-        PackageUpdated(idPackage,name);
+        PackageUpdated(idPackage, name);
     }
 
     /// @notice Change the status of a DAppNode package
@@ -139,8 +139,7 @@ contract DAppNodePackageDirectory is Owned,Escapable {
     /// @param _featured List of the ids of the featured packages
     /// if needed ids [5,43]: _featured = 0x052b0000000000000...
     function changeFeatured(
-        bytes32 _featured,
-        uint128 newPosition
+        bytes32 _featured
     ) public onlyOwner {
         featured = _featured;
         FeaturedChanged(_featured);

--- a/contracts/DAppNodePackageDirectory.sol
+++ b/contracts/DAppNodePackageDirectory.sol
@@ -27,18 +27,24 @@ import './Escapable.sol';
 
 contract DAppNodePackageDirectory is Owned,Escapable {
 
-    enum DAppNodePackageStatus {Preparing, Develop, Active, Deprecated, Deleted}
-
+    /// @param position Indicates the position of the package. position integers
+    /// do not have to be consecutive. The biggest integer will be shown first.
+    /// @param status - 0: Deleted, 1: Active, 2: Developing, +
+    /// @param name ENS name of the package
     struct DAppNodePackage {
+        uint128 position;
+        uint128 status;
         string name;
-        DAppNodePackageStatus status;
     }
 
+    bytes32 public featured;
     DAppNodePackage[] DAppNodePackages;
 
     event PackageAdded(uint indexed idPackage, string name);
     event PackageUpdated(uint indexed idPackage, string name);
-    event StatusChanged(uint idPackage, DAppNodePackageStatus newStatus);
+    event StatusChanged(uint idPackage, uint128 newStatus);
+    event PositionChanged(uint idPackage, uint128 newPosition);
+    event FeaturedChanged(bytes32 newFeatured);
 
     /// @notice The Constructor assigns the `escapeHatchDestination` and the
     ///  `escapeHatchCaller`
@@ -61,13 +67,23 @@ contract DAppNodePackageDirectory is Owned,Escapable {
 
     /// @notice Add a new DAppNode package
     /// @param name the ENS name of the package
+    /// @param status status of the package
+    /// @param position to order the packages in the UI
     /// @return the idPackage of the new package
     function addPackage (
-        string name
-    ) onlyOwner public returns(uint idPackage) {
+        string name,
+        uint128 status,
+        uint128 position
+    ) public onlyOwner returns(uint idPackage) {
         idPackage = DAppNodePackages.length++;
         DAppNodePackage storage c = DAppNodePackages[idPackage];
         c.name = name;
+        if (position == 0) {
+            c.position = uint128(1000 * (idPackage + 1));
+        } else {
+            c.position = position;
+        }
+        c.status = status;
         // An event to notify that a new package has been added
         PackageAdded(idPackage,name);
     }
@@ -75,13 +91,19 @@ contract DAppNodePackageDirectory is Owned,Escapable {
     /// @notice Update a DAppNode package
     /// @param idPackage the id of the package to be changed
     /// @param name the new ENS name of the package
+    /// @param status status of the package
+    /// @param position to order the packages in the UI
     function updatePackage (
         uint idPackage,
-        string name
-    ) onlyOwner public {
+        string name,
+        uint128 status,
+        uint128 position
+    ) public onlyOwner {
         require(idPackage < DAppNodePackages.length);
         DAppNodePackage storage c = DAppNodePackages[idPackage];
         c.name = name;
+        c.position = position;
+        c.status = status;
         // An event to notify that a package has been updated
         PackageUpdated(idPackage,name);
     }
@@ -91,27 +113,53 @@ contract DAppNodePackageDirectory is Owned,Escapable {
     /// @param newStatus the new status of the package
     function changeStatus(
         uint idPackage,
-        DAppNodePackageStatus newStatus
-    ) onlyOwner public {
+        uint128 newStatus
+    ) public onlyOwner {
         require(idPackage < DAppNodePackages.length);
         DAppNodePackage storage c = DAppNodePackages[idPackage];
         c.status = newStatus;
-        // An event to notify that the status of a packet has been updated
         StatusChanged(idPackage, newStatus);
+    }
+
+    /// @notice Change the status of a DAppNode package
+    /// @param idPackage the id of the package to be changed
+    /// @param newStatus the new status of the package
+    /// @param position to order the packages in the UI
+    function changePosition(
+        uint idPackage,
+        uint128 newPosition
+    ) public onlyOwner {
+        require(idPackage < DAppNodePackages.length);
+        DAppNodePackage storage c = DAppNodePackages[idPackage];
+        c.position = newPosition;
+        PositionChanged(idPackage, newPosition);
+    }
+
+    /// @notice Change the list of featured packages
+    /// @param _featured List of the ids of the featured packages
+    /// if needed ids [5,43]: _featured = 0x052b0000000000000...
+    function changeFeatured(
+        bytes32 _featured,
+        uint128 newPosition
+    ) public onlyOwner {
+        featured = _featured;
+        FeaturedChanged(_featured);
     }
 
     /// @notice Returns the information of a DAppNode package
     /// @param idPackage the id of the package to be changed
     /// @return name the new name of the package
     /// @return status the status of the package
-    function getPackage(uint idPackage) constant public returns (
+    function getPackage(uint idPackage) public view returns (
         string name,
-        DAppNodePackageStatus status
+        uint128 status,
+        uint128 position
     ) {
         require(idPackage < DAppNodePackages.length);
         DAppNodePackage storage c = DAppNodePackages[idPackage];
         name = c.name;
         status = c.status;
+        position = c.position;
     }
 
     /// @notice its goal is to return the total number of DAppNode packages

--- a/contracts/DAppNodePackageDirectory.sol
+++ b/contracts/DAppNodePackageDirectory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity ^0.5.10;
 
 /*
     Copyright 2018, Eduardo Antuña
@@ -56,9 +56,9 @@ contract DAppNodePackageDirectory is Owned,Escapable {
     ///  Multisig) to send the ether held in this contract; if a neutral address
     ///  is required, the WHG Multisig is an option:
     ///  0x8Ff920020c8AD673661c8117f2855C384758C572 
-    function DAppNodePackageDirectory(
+    constructor(
         address _escapeHatchCaller,
-        address _escapeHatchDestination
+        address payable _escapeHatchDestination
     ) 
         Escapable(_escapeHatchCaller, _escapeHatchDestination)
         public
@@ -71,7 +71,7 @@ contract DAppNodePackageDirectory is Owned,Escapable {
     /// @param position to order the packages in the UI
     /// @return the idPackage of the new package
     function addPackage (
-        string name,
+        string memory name,
         uint128 status,
         uint128 position
     ) public onlyOwner returns(uint idPackage) {
@@ -85,7 +85,7 @@ contract DAppNodePackageDirectory is Owned,Escapable {
         }
         c.status = status;
         // An event to notify that a new package has been added
-        PackageAdded(idPackage, name);
+        emit PackageAdded(idPackage, name);
     }
 
     /// @notice Update a DAppNode package
@@ -95,7 +95,7 @@ contract DAppNodePackageDirectory is Owned,Escapable {
     /// @param position to order the packages in the UI
     function updatePackage (
         uint idPackage,
-        string name,
+        string memory name,
         uint128 status,
         uint128 position
     ) public onlyOwner {
@@ -105,7 +105,7 @@ contract DAppNodePackageDirectory is Owned,Escapable {
         c.position = position;
         c.status = status;
         // An event to notify that a package has been updated
-        PackageUpdated(idPackage, name);
+        emit PackageUpdated(idPackage, name);
     }
 
     /// @notice Change the status of a DAppNode package
@@ -118,13 +118,33 @@ contract DAppNodePackageDirectory is Owned,Escapable {
         require(idPackage < DAppNodePackages.length);
         DAppNodePackage storage c = DAppNodePackages[idPackage];
         c.status = newStatus;
-        StatusChanged(idPackage, newStatus);
+        emit StatusChanged(idPackage, newStatus);
+    }
+    
+    /// @notice Switch the positio of two DAppNode packages
+    /// @param idPackage1 the id of the package to be switched
+    /// @param idPackage2 the id of the package to be switched
+    function switchPosition(
+        uint idPackage1,
+        uint idPackage2
+    ) public onlyOwner {
+        require(idPackage1 < DAppNodePackages.length);
+        require(idPackage2 < DAppNodePackages.length);
+
+        DAppNodePackage storage p1 = DAppNodePackages[idPackage1];
+        DAppNodePackage storage p2 = DAppNodePackages[idPackage2];
+        
+        uint128 tmp = p1.position;
+        p1.position = p2.position;
+        p2.position = tmp;
+        emit PositionChanged(idPackage1, p1.position);
+        emit PositionChanged(idPackage2, p2.position);
+
     }
 
     /// @notice Change the status of a DAppNode package
     /// @param idPackage the id of the package to be changed
-    /// @param newStatus the new status of the package
-    /// @param position to order the packages in the UI
+    /// @param newPosition position to order the packages in the UI
     function changePosition(
         uint idPackage,
         uint128 newPosition
@@ -132,7 +152,7 @@ contract DAppNodePackageDirectory is Owned,Escapable {
         require(idPackage < DAppNodePackages.length);
         DAppNodePackage storage c = DAppNodePackages[idPackage];
         c.position = newPosition;
-        PositionChanged(idPackage, newPosition);
+        emit PositionChanged(idPackage, newPosition);
     }
 
     /// @notice Change the list of featured packages
@@ -142,7 +162,7 @@ contract DAppNodePackageDirectory is Owned,Escapable {
         bytes32 _featured
     ) public onlyOwner {
         featured = _featured;
-        FeaturedChanged(_featured);
+        emit FeaturedChanged(_featured);
     }
 
     /// @notice Returns the information of a DAppNode package
@@ -150,7 +170,7 @@ contract DAppNodePackageDirectory is Owned,Escapable {
     /// @return name the new name of the package
     /// @return status the status of the package
     function getPackage(uint idPackage) public view returns (
-        string name,
+        string memory name,
         uint128 status,
         uint128 position
     ) {

--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity ^0.5.10;
 
 
 /**
@@ -9,10 +9,10 @@ pragma solidity ^0.4.19;
 contract ERC20 {
   
     /// @dev Returns the total token supply
-    function totalSupply() public constant returns (uint256 supply);
+    function totalSupply() public view returns (uint256 supply);
 
     /// @dev Returns the account balance of the account with address _owner
-    function balanceOf(address _owner) public constant returns (uint256 balance);
+    function balanceOf(address _owner) public view returns (uint256 balance);
 
     /// @dev Transfers _value number of tokens to address _to
     function transfer(address _to, uint256 _value) public returns (bool success);
@@ -24,7 +24,7 @@ contract ERC20 {
     function approve(address _spender, uint256 _value) public returns (bool success);
 
     /// @dev Returns the amount which _spender is still allowed to withdraw from _owner
-    function allowance(address _owner, address _spender) public constant returns (uint256 remaining);
+    function allowance(address _owner, address _spender) public view returns (uint256 remaining);
 
     event Transfer(address indexed _from, address indexed _to, uint256 _value);
     event Approval(address indexed _owner, address indexed _spender, uint256 _value);

--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity ^0.5.10;
 
 
 /// @title Owned
@@ -20,7 +20,7 @@ contract Owned {
     event OwnershipRemoved();
 
     /// @dev The constructor sets the `msg.sender` as the`owner` of the contract
-    function Owned() public {
+    constructor() public {
         owner = msg.sender;
     }
 
@@ -39,7 +39,7 @@ contract Owned {
     /// @param _newOwnerCandidate The address being proposed as the new owner
     function proposeOwnership(address _newOwnerCandidate) public onlyOwner {
         newOwnerCandidate = _newOwnerCandidate;
-        OwnershipRequested(msg.sender, newOwnerCandidate);
+        emit OwnershipRequested(msg.sender, newOwnerCandidate);
     }
 
     /// @notice Can only be called by the `newOwnerCandidate`, accepts the
@@ -49,9 +49,9 @@ contract Owned {
 
         address oldOwner = owner;
         owner = newOwnerCandidate;
-        newOwnerCandidate = 0x0;
+        newOwnerCandidate = address(0);
 
-        OwnershipTransferred(oldOwner, owner);
+        emit OwnershipTransferred(oldOwner, owner);
     }
 
     /// @dev In this 2nd option for ownership transfer `changeOwnership()` can
@@ -59,13 +59,13 @@ contract Owned {
     /// @notice `owner` can step down and assign some other address to this role
     /// @param _newOwner The address of the new owner
     function changeOwnership(address _newOwner) public onlyOwner {
-        require(_newOwner != 0x0);
+        require(_newOwner != address(0));
 
         address oldOwner = owner;
         owner = _newOwner;
-        newOwnerCandidate = 0x0;
+        newOwnerCandidate = address(0);
 
-        OwnershipTransferred(oldOwner, owner);
+        emit OwnershipTransferred(oldOwner, owner);
     }
 
     /// @dev In this 3rd option for ownership transfer `removeOwnership()` can
@@ -74,9 +74,9 @@ contract Owned {
     /// @notice Decentralizes the contract, this operation cannot be undone 
     /// @param _dac `0xdac` has to be entered for this function to work
     function removeOwnership(address _dac) public onlyOwner {
-        require(_dac == 0xdac);
-        owner = 0x0;
-        newOwnerCandidate = 0x0;
-        OwnershipRemoved();     
+        require(_dac == address(0xdAc0000000000000000000000000000000000000));
+        owner = address(0);
+        newOwnerCandidate = address(0);
+        emit OwnershipRemoved();     
     }
 } 


### PR DESCRIPTION
## Position
Allows individual ordering of each package. It works like the CSS z-index property. Position values don't have to be consecutive, they are an unsigned integer between 0 and 3.4e38 and will be ordered accordingly. As a convetion, it would be recommended that the position value is initially set at 
```go
position = uint128(1000 * (idPackage + 1));
```
spacing out values by 1000.
To trigger this behavior one must call addPackage with a position value of 0
```go
addPackage("ropsten.dnp.dappnode.eth", 1, 0)
```
Packages will be ordered by bigger position values at the top.

## Featured
Is a list of `idPackage`s that represent which ids must be flagged as featured, encoded as a bytes32.
If needed `idPackage [5,43]`, then `_featured = 0x052b0000000000000...`
@eduadiez should we do?
- 2 bytes per package: So 65,535 max packages in the directory ever / 16 max featured packages at once
- 1 bytes per package: So 255 max packages in the directory ever / 32 max featured packages at once
